### PR TITLE
Backfill on Strava link and hydrate via webhook

### DIFF
--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -58,6 +58,14 @@ export const authOptions: NextAuthOptions = {
           },
           data: { athlete_id: account.providerAccountId },
         });
+
+        // Kick off initial backfill when Strava is first linked
+        if (account.userId) {
+          const { backfillAllActivities } = await import("@/lib/strava-sync");
+          backfillAllActivities(account.userId).catch((e) =>
+            console.error("backfill error", e)
+          );
+        }
       }
     },
   },


### PR DESCRIPTION
## Summary
- trigger initial Strava backfill when a user links their account
- enhance Strava webhook to fetch activity detail and stream data

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68acfea8d0e883288439eecca1d5cd92