### PR TITLE
Handle missing Strava streams gracefully

### DIFF
--- a/src/app/api/strava/sync-details/route.ts
+++ b/src/app/api/strava/sync-details/route.ts
@@ -69,6 +69,7 @@ export async function GET() {
     // 2) Streams
     try {
       const s = await getActivityStreams(id, accessToken);
+      if (!s) continue;
 
       await db.activityStream.upsert({
         where: { activityId: id },

--- a/src/app/api/strava/webhook/route.ts
+++ b/src/app/api/strava/webhook/route.ts
@@ -142,6 +142,7 @@ async function fetchAndStoreActivity(userId: string, activityId: string) {
 
   try {
     const s = await getActivityStreams(activityId, token);
+    if (!s) return;
     await db.activityStream.upsert({
       where: { activityId },
       create: {

--- a/src/lib/strava.ts
+++ b/src/lib/strava.ts
@@ -129,7 +129,7 @@ export async function getActivityDetail(
 export async function getActivityStreams(
   activityId: string,
   accessToken: string
-) {
+): Promise<Record<string, { data: any[] }> | null> {
   const keys = [
     "time",
     "heartrate",
@@ -146,6 +146,10 @@ export async function getActivityStreams(
     headers: { Authorization: `Bearer ${accessToken}` },
     cache: "no-store",
   });
+  if (r.status === 404) {
+    // Streams may not be ready or activity may lack them.
+    return null;
+  }
   if (!r.ok) {
     const t = await r.text();
     throw new Error(`Strava streams ${activityId} failed: ${r.status} ${t}`);


### PR DESCRIPTION
## Summary
- treat 404 responses from Strava streams as no data instead of throwing
- avoid logging errors when streams are absent for new activities
- skip stream upserts when Strava hasn't generated streams yet

## Testing
- `npm run lint`
- `npx tsc -p tsconfig.json --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_68ad45450d048328a136a245d04359c5