### PR TITLE
Add manual refresh for missing Strava activities

### DIFF
--- a/src/app/api/strava/refresh/route.ts
+++ b/src/app/api/strava/refresh/route.ts
@@ -1,0 +1,124 @@
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth";
+import { json } from "@/lib/http";
+import { db } from "@/lib/db";
+import {
+  ensureStravaAccessToken,
+  listAthleteActivities,
+  getActivityDetail,
+  getActivityStreams,
+  getStravaAccountForUser,
+} from "@/lib/strava";
+import { upsertActivity } from "@/lib/strava-sync";
+
+export async function POST() {
+  const session = await getServerSession(authOptions);
+  if (!session?.user)
+    return json({ ok: false, error: "Unauthorized" }, { status: 401 });
+  const userId = (session.user as any).id as string;
+
+  const acct = await getStravaAccountForUser(userId);
+  if (!acct)
+    return json({ ok: false, error: "Strava not linked" }, { status: 400 });
+
+  const accessToken = await ensureStravaAccessToken(userId);
+
+  // Fetch a reasonable number of recent activities
+  const perPage = 100;
+  const maxPages = 5;
+  const summaries: Record<string, any> = {};
+
+  for (let page = 1; page <= maxPages; page++) {
+    const batch = await listAthleteActivities(accessToken, page, perPage);
+    if (!batch.length) break;
+    for (const a of batch) {
+      summaries[String(a.id)] = a;
+    }
+    await new Promise((res) => setTimeout(res, 350));
+  }
+
+  const ids = Object.keys(summaries);
+  if (ids.length === 0)
+    return json({ ok: true, checked: 0, added: 0, streamed: 0 });
+
+  const existing = await db.activity.findMany({
+    where: { userId, id: { in: ids } },
+    select: { id: true },
+  });
+  const existingSet = new Set(existing.map((a) => a.id));
+  const missingIds = ids.filter((id) => !existingSet.has(id));
+
+  let added = 0;
+  let streamed = 0;
+
+  for (const id of missingIds) {
+    try {
+      const detail = await getActivityDetail(id, accessToken);
+      await upsertActivity(userId, detail);
+      await db.activity.update({
+        where: { id },
+        data: {
+          raw_detail: detail as any,
+          avg_hr: detail.average_heartrate ?? null,
+          max_hr: detail.max_heartrate ?? null,
+          avg_speed: detail.average_speed ?? null,
+          avg_cadence: detail.average_cadence ?? null,
+          avg_watts: detail.average_watts ?? null,
+          calories: detail.calories ?? null,
+          device_name: detail.device_name ?? null,
+          map_polyline: detail.map?.summary_polyline ?? null,
+        },
+      });
+      added++;
+
+      try {
+        const s = await getActivityStreams(id, accessToken);
+        if (s) {
+          await db.activityStream.upsert({
+            where: { activityId: id },
+            create: {
+              activityId: id,
+              time: s.time?.data ?? null,
+              heartrate: s.heartrate?.data ?? null,
+              velocity_smooth: s.velocity_smooth?.data ?? null,
+              altitude: s.altitude?.data ?? null,
+              cadence: s.cadence?.data ?? null,
+              watts: s.watts?.data ?? null,
+              grade_smooth: s.grade_smooth?.data ?? null,
+              latlng: s.latlng?.data ?? null,
+            },
+            update: {
+              time: s.time?.data ?? null,
+              heartrate: s.heartrate?.data ?? null,
+              velocity_smooth: s.velocity_smooth?.data ?? null,
+              altitude: s.altitude?.data ?? null,
+              cadence: s.cadence?.data ?? null,
+              watts: s.watts?.data ?? null,
+              grade_smooth: s.grade_smooth?.data ?? null,
+              latlng: s.latlng?.data ?? null,
+            },
+          });
+
+          await db.activity.update({
+            where: { id },
+            data: { has_streams: true },
+          });
+
+          streamed++;
+        }
+      } catch (e) {
+        console.error("stream error", id, e);
+      }
+    } catch (e) {
+      console.error("refresh error", id, e);
+    }
+  }
+
+  return json({
+    ok: true,
+    checked: ids.length,
+    missing: missingIds.length,
+    added,
+    streamed,
+  });
+}

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -9,6 +9,7 @@ import SignOutButton from "@/components/SignOutButton";
 import TrainingStatus from "@/components/TrainingStatus";
 import WeeklyStats from "@/components/WeeklyStats";
 import BackfillButton from "@/components/BackfillButton";
+import RefreshButton from "@/components/RefreshButton";
 import TrainingCharts from "@/components/TrainingCharts";
 import Last7Days from "@/components/Last7Days";
 
@@ -99,16 +100,9 @@ export default async function DashboardPage() {
             </div>
 
             <div className="flex flex-wrap gap-3">
-              {/* client components */}
-
-              {/* <SyncStravaButton />
-
-              <SyncStravaDetailsButton /> */}
-
+              <RefreshButton />
               {hasStrava && !syncState?.backfillDone ? (
-                <div className="mt-3">
-                  <BackfillButton />
-                </div>
+                <BackfillButton />
               ) : (
                 <div className="inline-flex items-center gap-2 rounded-md bg-emerald-50 px-3 py-2 text-emerald-700 ring-1 ring-inset ring-emerald-200">
                   <span className="h-2 w-2 rounded-full bg-emerald-500" />

--- a/src/components/RefreshButton.tsx
+++ b/src/components/RefreshButton.tsx
@@ -3,28 +3,26 @@
 import { useState } from "react";
 
 export default function RefreshButton() {
-  const [msg, setMsg] = useState("");
   const [loading, setLoading] = useState(false);
+  const [toast, setToast] = useState<string | null>(null);
 
   async function run() {
     setLoading(true);
-    setMsg("Refreshing…");
     try {
       const r = await fetch("/api/strava/refresh", { method: "POST" });
       const j = await r.json();
       if (!j.ok) throw new Error(j.error || "failed");
-      setMsg(
-        `Checked ${j.checked} • missing ${j.missing} • added ${j.added} • streamed ${j.streamed}`
-      );
+      setToast(`Added ${j.added} activities`);
     } catch (e: any) {
-      setMsg(`Error: ${e.message || "failed"}`);
+      setToast(`Error: ${e.message || "failed"}`);
     } finally {
       setLoading(false);
+      setTimeout(() => setToast(null), 3000);
     }
   }
 
   return (
-    <div className="inline-flex items-center gap-3">
+    <>
       <button
         onClick={run}
         disabled={loading}
@@ -32,7 +30,12 @@ export default function RefreshButton() {
       >
         {loading ? "Refreshing…" : "Refresh Activities"}
       </button>
-      {msg && <span className="text-sm text-slate-600">{msg}</span>}
-    </div>
+      {toast && (
+        <div className="fixed bottom-4 left-1/2 z-50 -translate-x-1/2 rounded bg-slate-800 px-4 py-2 text-sm text-white shadow">
+          {toast}
+        </div>
+      )}
+    </>
   );
 }
+

--- a/src/components/RefreshButton.tsx
+++ b/src/components/RefreshButton.tsx
@@ -1,0 +1,38 @@
+// src/components/RefreshButton.tsx
+"use client";
+import { useState } from "react";
+
+export default function RefreshButton() {
+  const [msg, setMsg] = useState("");
+  const [loading, setLoading] = useState(false);
+
+  async function run() {
+    setLoading(true);
+    setMsg("Refreshing…");
+    try {
+      const r = await fetch("/api/strava/refresh", { method: "POST" });
+      const j = await r.json();
+      if (!j.ok) throw new Error(j.error || "failed");
+      setMsg(
+        `Checked ${j.checked} • missing ${j.missing} • added ${j.added} • streamed ${j.streamed}`
+      );
+    } catch (e: any) {
+      setMsg(`Error: ${e.message || "failed"}`);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <div className="inline-flex items-center gap-3">
+      <button
+        onClick={run}
+        disabled={loading}
+        className="inline-flex items-center rounded-lg border border-slate-300 bg-white px-4 py-2 text-sm font-medium text-slate-900 shadow-sm hover:bg-slate-50 disabled:opacity-60 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500"
+      >
+        {loading ? "Refreshing…" : "Refresh Activities"}
+      </button>
+      {msg && <span className="text-sm text-slate-600">{msg}</span>}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add API endpoint to search Strava for missing activities and download detail and streams
- add client-side Refresh button and surface on dashboard

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68ae53fe2cd08328a9408333cebe15c3